### PR TITLE
Add error handling and integration tests for invalid inputs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .count() as u32;
 
+    if frame_count == 0 {
+        return Err(format!("❌ No PNG files found in '{}'.", working_input_path.display()).into());
+    }
+
     let duration = frame_count as f32 / args.fps as f32;
 
     // Build fade filter if requested

--- a/src/utils/unzip_frames.rs
+++ b/src/utils/unzip_frames.rs
@@ -16,6 +16,7 @@ pub fn unzip_frames(zip_path: &Path) -> Result<(PathBuf, tempfile::TempDir), Box
 
     let temp_path = temp_dir.path().to_path_buf();
 
+    let mut extracted = 0u32;
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)
             .map_err(|e| format!("❌ Failed to access file in zip at index {}: {}", i, e))?;
@@ -33,6 +34,11 @@ pub fn unzip_frames(zip_path: &Path) -> Result<(PathBuf, tempfile::TempDir), Box
             .map_err(|e| format!("❌ Failed to copy content to '{}': {}", full_out_path.display(), e))?;
 
         println!("✅ Extracting: {}", full_out_path.display());
+        extracted += 1;
+    }
+
+    if extracted == 0 {
+        return Err("❌ No PNG files found in zip archive".into());
     }
 
     println!("🗂️  Extracted frames to: {}", temp_path.display());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -64,3 +64,65 @@ fn cli_renders_webm() -> Result<(), Box<dyn std::error::Error>> {
     // TempDir cleans up automatically
     Ok(())
 }
+
+#[test]
+fn cli_errors_on_invalid_zip() -> Result<(), Box<dyn std::error::Error>> {
+    let zip_path = Path::new("tests/testdata/two-frames-error.zip");
+    assert!(zip_path.exists(), "test zip not found: {}", zip_path.display());
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "--input",
+            zip_path.to_str().unwrap(),
+            "--output",
+            "out.webm",
+        ])
+        .status()?;
+
+    assert!(!status.success(), "expected failure for invalid zip input");
+    Ok(())
+}
+
+#[test]
+fn cli_errors_on_missing_folder() -> Result<(), Box<dyn std::error::Error>> {
+    let missing = Path::new("tests/testdata/does_not_exist");
+    assert!(!missing.exists());
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "--input",
+            missing.to_str().unwrap(),
+            "--output",
+            "out.webm",
+        ])
+        .status()?;
+
+    assert!(!status.success(), "expected failure for missing input folder");
+    Ok(())
+}
+
+#[test]
+fn cli_errors_on_empty_folder() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempdir()?;
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "--input",
+            tmp.path().to_str().unwrap(),
+            "--output",
+            "out.webm",
+        ])
+        .status()?;
+
+    assert!(!status.success(), "expected failure for empty input folder");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- return an error if unzip_frames finds no PNGs
- error when CLI input folder has no PNG frames
- add integration tests covering invalid zip files, empty folders, and missing folders

## Testing
- `cargo test --all -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6844b8f82b448330a823dcbd992880d9