### PR TITLE
Add bitrate and CRF flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Built with love for artists, developers, and sacred animation workflows.
 - ✅ `.mp4` fallback (no alpha)
 - ✅ CLI flags for FPS, input folder, output path, format
 - ✅ Optional `--fade-in` and `--fade-out` for smooth loops
+- ✅ Optional `--bitrate` and `--crf` for quality control
 - ✅ Handle errors & missing frames gracefully
 
 ---
@@ -31,7 +32,9 @@ cargo run --release -- \
   --fps 30 \
   --format webm \
   --fade-in 1 \
-  --fade-out 1
+  --fade-out 1 \
+  --bitrate 2M \
+  --crf 23
 ```
 
 The `--fade-in` and `--fade-out` flags apply ffmpeg's [`fade`](https://ffmpeg.org/ffmpeg-filters.html#fade) filter under the hood. The start of the fade out is automatically calculated from the frame count and FPS.
@@ -150,7 +153,7 @@ Here’s one frame from the sacred animation:
 
 - [x] Render `.png` → `.webm` (with alpha)
 - [x] Support `.mp4` export
-- [ ] Add bitrate / CRF quality control
+- [x] Add bitrate / CRF quality control
 - [x] `--fade-in`, `--fade-out` for soft loops
 - [x] Handle errors & missing frames gracefully
 - [ ] Add optional CLI preview

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,14 @@ struct Args {
     /// Fade out duration in seconds
     #[arg(long, default_value_t = 0.0)]
     fade_out: f32,
+
+    /// Video bitrate (e.g. "2M")
+    #[arg(long, value_name = "BITRATE")]
+    bitrate: Option<String>,
+
+    /// Constant rate factor quality
+    #[arg(long, value_name = "CRF")]
+    crf: Option<u32>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -200,6 +208,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "-auto-alt-ref".to_string(),
         "0".to_string(),
     ];
+
+    if let Some(ref bitrate) = args.bitrate {
+        ffmpeg_args.push("-b:v".to_string());
+        ffmpeg_args.push(bitrate.clone());
+    }
+
+    if let Some(crf) = args.crf {
+        ffmpeg_args.push("-crf".to_string());
+        ffmpeg_args.push(crf.to_string());
+    }
 
     if !fade_filter.is_empty() {
         ffmpeg_args.push("-vf".to_string());


### PR DESCRIPTION
## Summary
- add optional `--bitrate` and `--crf` CLI arguments
- pass these values through to ffmpeg when present
- document new flags in README and roadmap

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845785f676c83308478037f7546f7b5