### PR TITLE
Add preview flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Built with love for artists, developers, and sacred animation workflows.
 - ✅ CLI flags for FPS, input folder, output path, format
 - ✅ Optional `--fade-in` and `--fade-out` for smooth loops
 - ✅ Optional `--bitrate` and `--crf` for quality control
+- ✅ Optional `--preview` to open the video after export
 - ✅ Handle errors & missing frames gracefully
 
 ---
@@ -34,7 +35,8 @@ cargo run --release -- \
   --fade-in 1 \
   --fade-out 1 \
   --bitrate 2M \
-  --crf 23
+  --crf 23 \
+  --preview
 ```
 
 The `--fade-in` and `--fade-out` flags apply ffmpeg's [`fade`](https://ffmpeg.org/ffmpeg-filters.html#fade) filter under the hood. The start of the fade out is automatically calculated from the frame count and FPS.
@@ -156,7 +158,7 @@ Here’s one frame from the sacred animation:
 - [x] Add bitrate / CRF quality control
 - [x] `--fade-in`, `--fade-out` for soft loops
 - [x] Handle errors & missing frames gracefully
-- [ ] Add optional CLI preview
+- [x] Add optional CLI preview
 - [ ] Begin GUI version with Tauri (`aether-renderer`) 🌟
 
 ---


### PR DESCRIPTION
## Summary
- support optional `--preview` flag that opens the rendered video
- document preview flag in README and roadmap

## Testing
- `cargo check`
- `cargo test`
- `cargo fmt -- --check` *(fails: rustfmt component missing)*

------
https://chatgpt.com/codex/tasks/task_e_68457c05fd3483308212fce0fed7e413