### PR TITLE
Add inline CLI mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,12 @@ pub fn render_from_config(config_path: &str) -> Result<(), String> {
     let args: RenderConfig = serde_json::from_str(&config_str)
         .map_err(|e| format!("❌ Failed to parse config: {}", e))?;
 
+    render(args)
+}
+
+/// Render using an already parsed configuration
+pub fn render(args: RenderConfig) -> Result<(), String> {
+
     // Check for ffmpeg availability upfront
     match Command::new("ffmpeg").arg("-version").status() {
         Ok(s) if s.success() => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,65 @@
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::path::PathBuf;
 
 /// 🌸 Aether Renderer Core
 #[derive(Parser, Debug)]
 #[command(name = "aether-renderer")]
-#[command(about = "Render using configuration file", long_about = None)]
+#[command(about = "Render using configuration file or inline options", long_about = None)]
 struct Args {
     /// Path to render configuration JSON
     #[arg(short, long)]
-    config: PathBuf,
+    config: Option<PathBuf>,
+
+    /// Input frames folder or ZIP
+    #[arg(short, long)]
+    input: Option<PathBuf>,
+
+    /// Output video path
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Enable verbose logging
+    #[arg(long)]
+    verbose: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    aether_renderer_core::render_from_config(args.config.to_str().unwrap()).map_err(|e| e.into())
+
+    if let Some(config) = args.config {
+        if args.verbose {
+            println!("Loading config from {}", config.display());
+        }
+        return aether_renderer_core::render_from_config(config.to_str().unwrap())
+            .map_err(|e| e.into());
+    }
+
+    if let Some(input) = args.input {
+        let output = args
+            .output
+            .unwrap_or_else(|| PathBuf::from("output.webm"));
+
+        if args.verbose {
+            println!("Rendering from CLI arguments");
+        }
+
+        let cfg = aether_renderer_core::RenderConfig {
+            input,
+            output: output.to_string_lossy().into_owned(),
+            fps: 30,
+            format: "webm".into(),
+            fade_in: 0.0,
+            fade_out: 0.0,
+            bitrate: None,
+            crf: None,
+            preview: false,
+            file_pattern: None,
+        };
+
+        return aether_renderer_core::render(cfg).map_err(|e| e.into());
+    }
+
+    Args::command().print_help()?;
+    println!();
+    Err("No input provided".into())
 }


### PR DESCRIPTION
## Summary
- allow `--input` and `--output` arguments in addition to `--config`
- support `--verbose` flag
- expose new `render` function for building config from CLI

## Testing
- `cargo test`
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_684703f6d8c8833092a7cdf168c0a6aa