### PR TITLE
Handle glob patterns for ffmpeg inputs

### DIFF
--- a/src/ffmpeg/gif.rs
+++ b/src/ffmpeg/gif.rs
@@ -10,15 +10,20 @@ pub fn render_gif(
 ) -> Result<(), String> {
     let palette_path = "palette.png";
 
+    let mut palette_args: Vec<String> = Vec::new();
+    if input_pattern.contains('*') {
+        palette_args.push("-pattern_type".into());
+        palette_args.push("glob".into());
+    }
+    palette_args.push("-i".into());
+    palette_args.push(input_pattern.into());
+    palette_args.push("-vf".into());
+    palette_args.push("fps=30,scale=640:-1:flags=lanczos,palettegen".into());
+    palette_args.push("-y".into());
+    palette_args.push(palette_path.into());
+
     let palette_status = match Command::new("ffmpeg")
-        .args([
-            "-i",
-            input_pattern,
-            "-vf",
-            "fps=30,scale=640:-1:flags=lanczos,palettegen",
-            "-y",
-            palette_path,
-        ])
+        .args(&palette_args)
         .status()
     {
         Ok(s) => s,
@@ -45,19 +50,22 @@ pub fn render_gif(
             gif_filter.push_str(filter);
         }
     }
+    let mut gif_args: Vec<String> = vec!["-framerate".into(), fps.to_string()];
+    if input_pattern.contains('*') {
+        gif_args.push("-pattern_type".into());
+        gif_args.push("glob".into());
+    }
+    gif_args.push("-i".into());
+    gif_args.push(input_pattern.into());
+    gif_args.push("-i".into());
+    gif_args.push(palette_path.into());
+    gif_args.push("-lavfi".into());
+    gif_args.push(format!("{} [x]; [x][1:v] paletteuse", gif_filter));
+    gif_args.push("-y".into());
+    gif_args.push(output.into());
+
     let gif_status = match Command::new("ffmpeg")
-        .args([
-            "-framerate",
-            &fps.to_string(),
-            "-i",
-            input_pattern,
-            "-i",
-            palette_path,
-            "-lavfi",
-            &format!("{} [x]; [x][1:v] paletteuse", gif_filter),
-            "-y",
-            output,
-        ])
+        .args(&gif_args)
         .status()
     {
         Ok(s) => s,

--- a/src/ffmpeg/gif.rs
+++ b/src/ffmpeg/gif.rs
@@ -22,10 +22,7 @@ pub fn render_gif(
     palette_args.push("-y".into());
     palette_args.push(palette_path.into());
 
-    let palette_status = match Command::new("ffmpeg")
-        .args(&palette_args)
-        .status()
-    {
+    let palette_status = match Command::new("ffmpeg").args(&palette_args).status() {
         Ok(s) => s,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {
@@ -64,10 +61,7 @@ pub fn render_gif(
     gif_args.push("-y".into());
     gif_args.push(output.into());
 
-    let gif_status = match Command::new("ffmpeg")
-        .args(&gif_args)
-        .status()
-    {
+    let gif_status = match Command::new("ffmpeg").args(&gif_args).status() {
         Ok(s) => s,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {

--- a/src/ffmpeg/video.rs
+++ b/src/ffmpeg/video.rs
@@ -27,18 +27,24 @@ pub fn render_video(
         _ => unreachable!(),
     };
 
-    let mut args: Vec<String> = vec![
-        "-framerate".into(),
-        fps.to_string(),
-        "-i".into(),
-        input_pattern.to_string(),
+    let mut args: Vec<String> = vec!["-framerate".into(), fps.to_string()];
+
+    if input_pattern.contains('*') {
+        args.push("-pattern_type".into());
+        args.push("glob".into());
+    }
+
+    args.push("-i".into());
+    args.push(input_pattern.to_string());
+
+    args.extend_from_slice(&[
         "-c:v".into(),
         codec.to_string(),
         "-pix_fmt".into(),
         pix_fmt.to_string(),
         "-auto-alt-ref".into(),
         "0".into(),
-    ];
+    ]);
 
     if let Some(b) = bitrate {
         args.push("-b:v".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,8 @@ pub fn render(args: RenderConfig) -> Result<(), String> {
         .map_err(|e| format!("❌ Failed to read frames: {}", e))?;
     let frame_count = frames.len() as u32;
 
-    let input_pattern = working_input_path.join("frame_%04d.png");
+    // Use the provided file pattern when building the ffmpeg input string
+    let input_pattern = working_input_path.join(&pattern);
     let input_str = input_pattern.to_str().unwrap();
 
     if frame_count == 0 {


### PR DESCRIPTION
## Summary
- feed FFmpeg with the configured file pattern instead of always `frame_%04d.png`
- add `-pattern_type glob` when the input path contains `*`
- extend GIF palette and render steps to support glob input

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68473b499c8883309306b8bdfcf599bf