### PR TITLE
Return output path from render()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@ pub use config::RenderConfig;
 use std::process::Command;
 
 /// Load configuration from file then render
-pub fn render_from_config(config_path: &str) -> Result<(), String> {
+pub fn render_from_config(config_path: &str) -> Result<String, String> {
     let args = RenderConfig::from_file(config_path)?;
     render(args)
 }
 
 /// Orchestrate rendering from a parsed configuration
-pub fn render(args: RenderConfig) -> Result<(), String> {
+pub fn render(args: RenderConfig) -> Result<String, String> {
     // Check for ffmpeg availability upfront
     match Command::new("ffmpeg").arg("-version").status() {
         Ok(s) if s.success() => {}
@@ -110,5 +110,5 @@ pub fn render(args: RenderConfig) -> Result<(), String> {
             eprintln!("⚠️ Failed to open video preview: {}", e);
         }
     }
-    Ok(())
+    Ok(args.output.clone())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if args.verbose {
             println!("Loading config from {}", config.display());
         }
-        return aether_renderer_core::render_from_config(config.to_str().unwrap())
-            .map_err(|e| e.into());
+        let out = aether_renderer_core::render_from_config(config.to_str().unwrap())?;
+        if args.verbose {
+            println!("Rendered to {}", out);
+        }
+        return Ok(());
     }
 
     if let Some(input) = args.input {
@@ -71,7 +74,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             verbose: args.verbose,
         };
 
-        return aether_renderer_core::render(cfg).map_err(|e| e.into());
+        let out = aether_renderer_core::render(cfg)?;
+        if args.verbose {
+            println!("Rendered to {}", out);
+        }
+        return Ok(());
     }
 
     Args::command().print_help()?;


### PR DESCRIPTION
## Summary
- change `render_from_config` and `render` to return `Result<String, String>`
- propagate the returned output path in `main.rs` when verbose

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684753e68a8483308e7ca91a8af1ae3d