### PR TITLE
Add flag to toggle ffmpeg verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built with love for artists, developers, and sacred animation workflows.
 - 🎛️ Render using either `--config` file or inline CLI arguments
 - ✨ Cross-platform (macOS, Linux, Windows)
 - 🔒 Minimal dependencies, no runtime server required
+- 🤫 Quiet ffmpeg output by default (`--verbose-ffmpeg` for full logs)
 
 Built like a **triple-mode sacred core**:
 
@@ -77,6 +78,7 @@ CLI params override matching fields in the config.
 | `--crf`          | Number | *(none)*   | e.g. `23` for x264 (lower = better) |
 | `--preview`      | Flag   | false      | Enables preview mode                |
 | `--verbose`      | Flag   | false      | Prints detailed logs + progress bar |
+| `--verbose-ffmpeg` | Flag | false | Show full ffmpeg logs |
 
 ---
 
@@ -113,7 +115,8 @@ CLI params override matching fields in the config.
   "crf": 24,
   "preview": false,
   "file_pattern": "*.png",
-  "verbose": true
+  "verbose": true,
+  "verbose_ffmpeg": false
 }
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct RenderConfig {
     pub file_pattern: Option<String>,
     #[serde(default)]
     pub verbose: bool,
+    #[serde(default)]
+    pub verbose_ffmpeg: bool,
 }
 
 fn default_fps() -> u32 {

--- a/src/ffmpeg/gif.rs
+++ b/src/ffmpeg/gif.rs
@@ -7,6 +7,7 @@ pub fn render_gif(
     output: &str,
     fps: u32,
     fade_filter: Option<&str>,
+    verbose_ffmpeg: bool,
 ) -> Result<(), String> {
     let palette_path = "palette.png";
 
@@ -22,7 +23,13 @@ pub fn render_gif(
     palette_args.push("-y".into());
     palette_args.push(palette_path.into());
 
-    let palette_status = match Command::new("ffmpeg").args(&palette_args).status() {
+    let palette_status = match {
+        let mut cmd = Command::new("ffmpeg");
+        if !verbose_ffmpeg {
+            cmd.args(["-loglevel", "warning"]);
+        }
+        cmd.args(&palette_args).status()
+    } {
         Ok(s) => s,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {
@@ -61,7 +68,13 @@ pub fn render_gif(
     gif_args.push("-y".into());
     gif_args.push(output.into());
 
-    let gif_status = match Command::new("ffmpeg").args(&gif_args).status() {
+    let gif_status = match {
+        let mut cmd = Command::new("ffmpeg");
+        if !verbose_ffmpeg {
+            cmd.args(["-loglevel", "warning"]);
+        }
+        cmd.args(&gif_args).status()
+    } {
         Ok(s) => s,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {

--- a/src/ffmpeg/video.rs
+++ b/src/ffmpeg/video.rs
@@ -9,6 +9,7 @@ pub fn render_video(
     bitrate: Option<&str>,
     crf: Option<u32>,
     fade_filter: Option<&str>,
+    verbose_ffmpeg: bool,
 ) -> Result<(), String> {
     let codec = match format {
         "webm" => "libvpx",
@@ -66,7 +67,13 @@ pub fn render_video(
     args.push("-y".into()); // Overwrite output file if it exists
     args.push(output.to_string());
 
-    let status = match Command::new("ffmpeg").args(&args).status() {
+    let status = match {
+        let mut cmd = Command::new("ffmpeg");
+        if !verbose_ffmpeg {
+            cmd.args(["-loglevel", "warning"]);
+        }
+        cmd.args(&args).status()
+    } {
         Ok(s) => s,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,17 @@ pub fn render_from_config(config_path: &str) -> Result<String, String> {
 /// Orchestrate rendering from a parsed configuration
 pub fn render(args: RenderConfig) -> Result<String, String> {
     // Check for ffmpeg availability upfront
-    match Command::new("ffmpeg").arg("-version").status() {
+    match {
+        let mut cmd = Command::new("ffmpeg");
+        cmd.arg("-version");
+
+        if !args.verbose_ffmpeg {
+            cmd.stdout(std::process::Stdio::null());
+            cmd.stderr(std::process::Stdio::null());
+        }
+
+        cmd.status()
+    } {
         Ok(s) if s.success() => {}
         Ok(_) => {
             return Err("❌ ffmpeg failed to run correctly.".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,13 @@ pub fn render(args: RenderConfig) -> Result<String, String> {
     };
 
     if args.format == "gif" {
-        ffmpeg::gif::render_gif(input_str, &args.output, args.fps, Some(&fade_filter))?;
+        ffmpeg::gif::render_gif(
+            input_str,
+            &args.output,
+            args.fps,
+            Some(&fade_filter),
+            args.verbose_ffmpeg,
+        )?;
     } else {
         ffmpeg::video::render_video(
             input_str,
@@ -119,6 +125,7 @@ pub fn render(args: RenderConfig) -> Result<String, String> {
             args.bitrate.as_deref(),
             args.crf,
             Some(&fade_filter),
+            args.verbose_ffmpeg,
         )?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,10 @@ struct Args {
     /// Enable verbose logging
     #[arg(long)]
     verbose: bool,
+
+    /// Show full ffmpeg logs
+    #[arg(long)]
+    verbose_ffmpeg: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -72,6 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             preview: args.preview,
             file_pattern: args.file_pattern,
             verbose: args.verbose,
+            verbose_ffmpeg: args.verbose_ffmpeg,
         };
 
         let out = aether_renderer_core::render(cfg)?;

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -20,6 +20,7 @@ fn benchmark_render_single_frame() -> Result<(), Box<dyn std::error::Error>> {
         crf: None,
         preview: false,
         verbose: false,
+        verbose_ffmpeg: false,
     };
 
     let start = Instant::now();


### PR DESCRIPTION
## Summary
- support `--verbose-ffmpeg` flag in CLI and config
- default to `-loglevel warning` when calling ffmpeg
- document the new flag

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68494bbf3da483308a4f8c53a17f1d35