### PR TITLE
Add preview frame extraction

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct RenderConfig {
     pub bitrate: Option<String>,
     #[serde(default)]
     pub crf: Option<u32>,
-    #[serde(default, rename = "preview")]
+    #[serde(default)]
     pub open: bool,
     #[serde(default)]
     pub file_pattern: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,8 @@ pub struct RenderConfig {
     pub bitrate: Option<String>,
     #[serde(default)]
     pub crf: Option<u32>,
-    #[serde(default)]
-    pub preview: bool,
+    #[serde(default, rename = "preview")]
+    pub open: bool,
     #[serde(default)]
     pub file_pattern: Option<String>,
     #[serde(default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,10 +146,61 @@ pub fn render(args: RenderConfig) -> Result<String, String> {
         pb.finish_with_message("✅ FFmpeg rendering complete!");
     }
 
-    if args.preview {
+    if args.open {
         if let Err(e) = utils::open_output(&args.output) {
             eprintln!("⚠️ Failed to open video preview: {}", e);
         }
     }
     Ok(args.output.clone())
+}
+
+/// Extract a single frame from an input folder or ZIP archive
+pub fn preview_frame(
+    input: &std::path::Path,
+    file_pattern: Option<String>,
+    frame_index: Option<usize>,
+    output: &std::path::Path,
+    verbose: bool,
+) -> Result<String, String> {
+    if !input.exists() {
+        return Err(format!("❌ Input path '{}' does not exist.", input.display()));
+    }
+
+    if input
+        .extension()
+        .map(|ext| ext == "zip")
+        .unwrap_or(false)
+    {
+        let count = utils::count_pngs_in_zip(input).map_err(|e| e.to_string())?;
+        if count == 0 {
+            return Err("❌ No PNG files found in zip archive".into());
+        }
+        let idx = frame_index.unwrap_or(count / 2);
+        if idx >= count {
+            return Err(format!("❌ Frame index {} out of range (0..{})", idx, count - 1));
+        }
+        utils::extract_frame_from_zip(input, idx, output).map_err(|e| e.to_string())?;
+    } else {
+        let pattern = file_pattern.clone().unwrap_or_else(|| "*.png".to_string());
+        let frames = input::collect_input_frames(input, Some(pattern.clone()))
+            .map_err(|e| format!("❌ Failed to read frames: {}", e))?;
+        if frames.is_empty() {
+            return Err(format!(
+                "❌ No input files found in '{}' matching pattern '{}'",
+                input.display(),
+                pattern
+            ));
+        }
+        let idx = frame_index.unwrap_or(frames.len() / 2);
+        if idx >= frames.len() {
+            return Err(format!("❌ Frame index {} out of range (0..{})", idx, frames.len() - 1));
+        }
+        std::fs::copy(&frames[idx], output)
+            .map_err(|e| format!("❌ Failed to copy frame: {}", e))?;
+    }
+
+    if verbose {
+        println!("🖼️ Preview saved to: {}", output.display());
+    }
+    Ok(output.to_string_lossy().into_owned())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,21 +163,24 @@ pub fn preview_frame(
     verbose: bool,
 ) -> Result<String, String> {
     if !input.exists() {
-        return Err(format!("❌ Input path '{}' does not exist.", input.display()));
+        return Err(format!(
+            "❌ Input path '{}' does not exist.",
+            input.display()
+        ));
     }
 
-    if input
-        .extension()
-        .map(|ext| ext == "zip")
-        .unwrap_or(false)
-    {
+    if input.extension().map(|ext| ext == "zip").unwrap_or(false) {
         let count = utils::count_pngs_in_zip(input).map_err(|e| e.to_string())?;
         if count == 0 {
             return Err("❌ No PNG files found in zip archive".into());
         }
         let idx = frame_index.unwrap_or(count / 2);
         if idx >= count {
-            return Err(format!("❌ Frame index {} out of range (0..{})", idx, count - 1));
+            return Err(format!(
+                "❌ Frame index {} out of range (0..{})",
+                idx,
+                count - 1
+            ));
         }
         utils::extract_frame_from_zip(input, idx, output).map_err(|e| e.to_string())?;
     } else {
@@ -193,7 +196,11 @@ pub fn preview_frame(
         }
         let idx = frame_index.unwrap_or(frames.len() / 2);
         if idx >= frames.len() {
-            return Err(format!("❌ Frame index {} out of range (0..{})", idx, frames.len() - 1));
+            return Err(format!(
+                "❌ Frame index {} out of range (0..{})",
+                idx,
+                frames.len() - 1
+            ));
         }
         std::fs::copy(&frames[idx], output)
             .map_err(|e| format!("❌ Failed to copy frame: {}", e))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,10 @@ struct Args {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
+    if args.preview.is_some() && args.open {
+        eprintln!("⚠️ '--open' is only supported for full render. Ignoring for preview.");
+    }
+
     if let Some(preview_arg) = args.preview {
         let input = args
             .input

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,8 +72,8 @@ pub fn unzip_frames(
 pub fn count_pngs_in_zip(zip_path: &Path) -> Result<usize, Box<dyn std::error::Error>> {
     let file = File::open(zip_path)
         .map_err(|e| format!("❌ Failed to open zip file '{}': {}", zip_path.display(), e))?;
-    let mut archive = ZipArchive::new(file)
-        .map_err(|e| format!("❌ Failed to read zip archive: {}", e))?;
+    let mut archive =
+        ZipArchive::new(file).map_err(|e| format!("❌ Failed to read zip archive: {}", e))?;
     let mut count = 0usize;
     for i in 0..archive.len() {
         let file = archive.by_index(i)?;
@@ -93,8 +93,8 @@ pub fn extract_frame_from_zip(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let file = File::open(zip_path)
         .map_err(|e| format!("❌ Failed to open zip file '{}': {}", zip_path.display(), e))?;
-    let mut archive = ZipArchive::new(file)
-        .map_err(|e| format!("❌ Failed to read zip archive: {}", e))?;
+    let mut archive =
+        ZipArchive::new(file).map_err(|e| format!("❌ Failed to read zip archive: {}", e))?;
     let mut png_indices = Vec::new();
     for i in 0..archive.len() {
         let f = archive.by_index(i)?;
@@ -107,15 +107,23 @@ pub fn extract_frame_from_zip(
         return Err("❌ No PNG files found in zip archive".into());
     }
     if frame_index >= png_indices.len() {
-        return Err(format!("❌ Frame index {} out of range (0..{})", frame_index, png_indices.len() - 1).into());
+        return Err(format!(
+            "❌ Frame index {} out of range (0..{})",
+            frame_index,
+            png_indices.len() - 1
+        )
+        .into());
     }
     let mut file = archive.by_index(png_indices[frame_index])?;
     let mut out = File::create(output).map_err(|e| {
-        format!("❌ Failed to create output file '{}': {}", output.display(), e)
+        format!(
+            "❌ Failed to create output file '{}': {}",
+            output.display(),
+            e
+        )
     })?;
-    std::io::copy(&mut file, &mut out).map_err(|e| {
-        format!("❌ Failed to copy content to '{}': {}", output.display(), e)
-    })?;
+    std::io::copy(&mut file, &mut out)
+        .map_err(|e| format!("❌ Failed to copy content to '{}': {}", output.display(), e))?;
     Ok(())
 }
 

--- a/tests/benchmark.rs
+++ b/tests/benchmark.rs
@@ -18,7 +18,7 @@ fn benchmark_render_single_frame() -> Result<(), Box<dyn std::error::Error>> {
         fade_out: 0.0,
         bitrate: None,
         crf: None,
-        preview: false,
+        open: false,
         verbose: false,
         verbose_ffmpeg: false,
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -202,3 +202,30 @@ fn cli_errors_on_empty_folder() -> Result<(), Box<dyn std::error::Error>> {
     assert!(!status.success(), "expected failure for empty input folder");
     Ok(())
 }
+
+#[test]
+fn cli_preview_from_zip() -> Result<(), Box<dyn std::error::Error>> {
+    let zip_path = Path::new("tests/testdata/two-frames.zip");
+    assert!(zip_path.exists());
+
+    let tmp = tempdir()?;
+    let out_file = tmp.path().join("prev.png");
+
+    let status = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "--input",
+            zip_path.to_str().unwrap(),
+            "--output",
+            out_file.to_str().unwrap(),
+            "--preview",
+            "1",
+        ])
+        .status()?;
+
+    assert!(status.success(), "cargo run failed");
+    assert!(out_file.exists(), "preview image not created");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `--preview` arg to extract a single frame without rendering
- rename old preview flag to `--open`
- implement library support for previewing frames
- update utils with zip helper functions
- test preview extraction via CLI

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684a2046e4a083309e61bdc1058db5d6